### PR TITLE
Fix some corruption in Balance

### DIFF
--- a/src/bore.c
+++ b/src/bore.c
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <math.h>
 #include <stdlib.h>
 #include <vapoursynth/VapourSynth4.h>
 #include <vapoursynth/VSHelper4.h>
@@ -275,7 +276,7 @@ static void processRowSLR(int row, int w, int h, ptrdiff_t stride, float *dstp) 
 
     int status = gsl_fit_mul(const_cur, 1, const_ref, 1, w, &c1, &cov11, &sumsq);
 
-    if (!status) {
+    if (!status && isfinite(c1)) {
         // adjust each pixel
         for (i = 0; i < w; i++) {
             dstp[i] *= c1;
@@ -312,7 +313,7 @@ static void processColumnSLR(int column, int w, int h, ptrdiff_t stride, float *
 
     int status = gsl_fit_mul(const_cur, 1, const_ref, 1, h, &c1, &cov11, &sumsq);
 
-    if (!status) {
+    if (!status && isfinite(c1)) {
         int j;
         // adjust each pixel
         for (i = 0; i < h; i++) {

--- a/src/bore.c
+++ b/src/bore.c
@@ -356,6 +356,12 @@ static void processRowMLR(int row, int w, int h, ptrdiff_t stride, float *dstp, 
             dstp[i] = gsl_vector_get(b, 0) * dstp1[i] + gsl_vector_get(b, 1) * dstp2[i] + gsl_vector_get(b, 2) * dstp3[i];
         }
     }
+
+    gsl_vector_free(b);
+    gsl_matrix_free(cov);
+    gsl_multifit_linear_free(ws);
+    gsl_matrix_free(x);
+    gsl_vector_free(y);
 }
 
 static void processColumnMLR(int column, int w, int h, ptrdiff_t stride, float *dstp, float *dstp1, float *dstp2, float *dstp3) {
@@ -387,6 +393,12 @@ static void processColumnMLR(int column, int w, int h, ptrdiff_t stride, float *
             dstp[j] = gsl_vector_get(b, 0) * dstp1[j] + gsl_vector_get(b, 1) * dstp2[j] + gsl_vector_get(b, 2) * dstp3[j];
         }
     }
+
+    gsl_vector_free(b);
+    gsl_matrix_free(cov);
+    gsl_multifit_linear_free(ws);
+    gsl_matrix_free(x);
+    gsl_vector_free(y);
 }
 
 static const VSFrame *VS_CC linearRegressionGetFrame(int n, int activationReason, void *instanceData, void **frameData, VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi) {

--- a/src/bore.c
+++ b/src/bore.c
@@ -273,11 +273,13 @@ static void processRowSLR(int row, int w, int h, ptrdiff_t stride, float *dstp) 
     const double *const_cur = cur;
     const double *const_ref = ref;
 
-    gsl_fit_mul(const_cur, 1, const_ref, 1, w, &c1, &cov11, &sumsq);
+    int status = gsl_fit_mul(const_cur, 1, const_ref, 1, w, &c1, &cov11, &sumsq);
 
-    // adjust each pixel
-    for (i = 0; i < w; i++) {
-        dstp[i] *= c1;
+    if (!status) {
+        // adjust each pixel
+        for (i = 0; i < w; i++) {
+            dstp[i] *= c1;
+        }
     }
 
     free(cur);
@@ -308,13 +310,15 @@ static void processColumnSLR(int column, int w, int h, ptrdiff_t stride, float *
     const double *const_cur = cur;
     const double *const_ref = ref;
 
-    gsl_fit_mul(const_cur, 1, const_ref, 1, h, &c1, &cov11, &sumsq);
+    int status = gsl_fit_mul(const_cur, 1, const_ref, 1, h, &c1, &cov11, &sumsq);
 
-    int j;
-    // adjust each pixel
-    for (i = 0; i < h; i++) {
-        j = i * stride;
-        dstp[j] *= c1;
+    if (!status) {
+        int j;
+        // adjust each pixel
+        for (i = 0; i < h; i++) {
+            j = i * stride;
+            dstp[j] *= c1;
+        }
     }
 
     free(cur);
@@ -344,11 +348,13 @@ static void processRowMLR(int row, int w, int h, ptrdiff_t stride, float *dstp, 
     double chisq;
     gsl_matrix *cov = gsl_matrix_alloc(3, 3);
     gsl_vector *b = gsl_vector_alloc(3);
-    gsl_multifit_linear(x, y, b, cov, &chisq, ws);
+    int status = gsl_multifit_linear(x, y, b, cov, &chisq, ws);
 
-    // adjust each pixel
-    for (i = 0; i < w; i++) {
-        dstp[i] = gsl_vector_get(b, 0) * dstp1[i] + gsl_vector_get(b, 1) * dstp2[i] + gsl_vector_get(b, 2) * dstp3[i];
+    if (!status) {
+        // adjust each pixel
+        for (i = 0; i < w; i++) {
+            dstp[i] = gsl_vector_get(b, 0) * dstp1[i] + gsl_vector_get(b, 1) * dstp2[i] + gsl_vector_get(b, 2) * dstp3[i];
+        }
     }
 }
 
@@ -372,12 +378,14 @@ static void processColumnMLR(int column, int w, int h, ptrdiff_t stride, float *
     double chisq;
     gsl_matrix *cov = gsl_matrix_alloc(3, 3);
     gsl_vector *b = gsl_vector_alloc(3);
-    gsl_multifit_linear(x, y, b, cov, &chisq, ws);
+    int status = gsl_multifit_linear(x, y, b, cov, &chisq, ws);
 
-    // adjust each pixel
-    for (i = 0; i < h; i++) {
-        j = i * stride + column;
-        dstp[j] = gsl_vector_get(b, 0) * dstp1[j] + gsl_vector_get(b, 1) * dstp2[j] + gsl_vector_get(b, 2) * dstp3[j];
+    if (!status) {
+        // adjust each pixel
+        for (i = 0; i < h; i++) {
+            j = i * stride + column;
+            dstp[j] = gsl_vector_get(b, 0) * dstp1[j] + gsl_vector_get(b, 1) * dstp2[j] + gsl_vector_get(b, 2) * dstp3[j];
+        }
     }
 }
 

--- a/src/bore.c
+++ b/src/bore.c
@@ -313,7 +313,7 @@ static void processColumnSLR(int column, int w, int h, ptrdiff_t stride, float *
     int j;
     // adjust each pixel
     for (i = 0; i < h; i++) {
-        j = i * stride + column;
+        j = i * stride;
         dstp[j] *= c1;
     }
 


### PR DESCRIPTION
You’ve already incremented `dstp` by `column` [18 lines above](https://github.com/OpusGang/bore/commit/0c10d6c62d6adb3e515f215c6771a2321b4157b8#diff-995c993f768288bcf48c604e8868878214c8e22926d05f95c67cbb90c07c295cR301), so this ends up writing to a wrong column with a doubled offset, creating a wave of alternating dark and bright lines:

![Input picture, cropped and upscaled, showing a smooth gradient from dark to bright.](https://github.com/OpusGang/bore/assets/515193/615ec572-46f4-4228-9092-81072e0e22fe) input
![Output of Balance, cropped and upscaled, showing vertical lines with non-monotonically varying brightness.](https://github.com/OpusGang/bore/assets/515193/c42550c1-b963-4e58-9824-cb1f6ea4b1fd) current output
![Output of fixed Balance, cropped and upscaled, showing a clean grey rectangle.](https://github.com/OpusGang/bore/assets/515193/61ee87df-82a3-4122-a693-2fc6fb7dff4f) fixed output (binary available [here](https://github.com/astiob/bore/actions/runs/8425875022/artifacts/1356960628))
(`left=10`, default `mode=0`, point-upscaled 8× to show the effect)

BTW the reason I’m trying `Balance` is that with `FixBrightness` I soon found frames in my source where the processed pixels get progressively brighter toward the edge of the frame like [this](https://slow.pics/c/nnLm8iaS) (noticeable on the right here). After this fix, `Balance` (without even the multiple regression, as the source is 4:2:0) seems to work nicely. If you need more samples, I can probably extract more frames from this source.

(Before `Balance`, I tried performing my own linreg on a few clean solid-colour or horizontal-gradient frames and applying the same coefficients to the whole clip, but while they worked beautifully for some scenes, they seemed completely wrong for others. Also, yes, I’ll be cropping this, although I’m torn between cropping off 2 and 4 pixels on each side.)