### PR TITLE
SinglePlaneDebug: output non-garbage values

### DIFF
--- a/src/avs_bore.c
+++ b/src/avs_bore.c
@@ -189,7 +189,6 @@ static AVS_VideoFrame* AVSC_CC singlePlaneDebugGetFrame(AVS_FilterInfo* fi, int 
     int h = avs_get_height_p(frame, plane);
     float* __restrict dstp = (float*)avs_get_write_ptr_p(frame, plane);
     double c1_cov11_sumsq[3] = { 0.0 };
-    double* props = c1_cov11_sumsq;
 
     if (d->weight_mask)
     {
@@ -200,32 +199,32 @@ static AVS_VideoFrame* AVSC_CC singlePlaneDebugGetFrame(AVS_FilterInfo* fi, int 
         {
             for (int row = top - 1; row > -1; --row)
             {
-                debugRowSLRMasked(row, w, h, stride, dstp, &props, wmaskp, wmaskstride, top - row);
-                set_frame_props(frame, props, fi->env);
+                debugRowSLRMasked(row, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, top - row);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
         if (bottom != 0)
         {
             for (int row = h - bottom; row < h; ++row)
             {
-                debugRowSLRMasked(row, w, h, stride, dstp, &props, wmaskp, wmaskstride, bottom + row - h + 1);
-                set_frame_props(frame, props, fi->env);
+                debugRowSLRMasked(row, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, bottom + row - h + 1);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
         if (left != 0)
         {
             for (int column = left - 1; column > -1; --column)
             {
-                debugColumnSLRMasked(column, w, h, stride, dstp, &props, wmaskp, wmaskstride, left - column);
-                set_frame_props(frame, props, fi->env);
+                debugColumnSLRMasked(column, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, left - column);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
         if (right != 0)
         {
             for (int column = w - right; column < w; ++column)
             {
-                debugColumnSLRMasked(column, w, h, stride, dstp, &props, wmaskp, wmaskstride, right + column - w + 1);
-                set_frame_props(frame, props, fi->env);
+                debugColumnSLRMasked(column, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, right + column - w + 1);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
 
@@ -237,32 +236,32 @@ static AVS_VideoFrame* AVSC_CC singlePlaneDebugGetFrame(AVS_FilterInfo* fi, int 
         {
             for (int row = top - 1; row > -1; --row)
             {
-                debugRowSLR(row, w, h, stride, dstp, &props);
-                set_frame_props(frame, props, fi->env);
+                debugRowSLR(row, w, h, stride, dstp, c1_cov11_sumsq);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
         if (bottom != 0)
         {
             for (int row = h - bottom; row < h; ++row)
             {
-                debugRowSLR(row, w, h, stride, dstp, &props);
-                set_frame_props(frame, props, fi->env);
+                debugRowSLR(row, w, h, stride, dstp, c1_cov11_sumsq);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
         if (left != 0)
         {
             for (int column = left - 1; column > -1; --column)
             {
-                debugColumnSLR(column, w, h, stride, dstp, &props);
-                set_frame_props(frame, props, fi->env);
+                debugColumnSLR(column, w, h, stride, dstp, c1_cov11_sumsq);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
         if (right != 0)
         {
             for (int column = w - right; column < w; ++column)
             {
-                debugColumnSLR(column, w, h, stride, dstp, &props);
-                set_frame_props(frame, props, fi->env);
+                debugColumnSLR(column, w, h, stride, dstp, c1_cov11_sumsq);
+                set_frame_props(frame, c1_cov11_sumsq, fi->env);
             }
         }
     }

--- a/src/bore.c
+++ b/src/bore.c
@@ -183,7 +183,6 @@ static const VSFrame *VS_CC singlePlaneDebugGetFrame(int n, int activationReason
         int h = vsapi->getFrameHeight(src, plane);
         float* __restrict dstp = (float *) vsapi->getWritePtr(dst, plane);
         double c1_cov11_sumsq[3] = { 0.0 };
-        double* props = c1_cov11_sumsq;
 
         if (d->weight_mask) {
             weight_mask = vsapi->getFrameFilter(n, d->weight_mask, frameCtx);
@@ -192,29 +191,29 @@ static const VSFrame *VS_CC singlePlaneDebugGetFrame(int n, int activationReason
             if (top != 0) {
                 for (int row = top - 1; row > -1; --row)
                 {
-                    debugRowSLRMasked(row, w, h, stride, dstp, &props, wmaskp, wmaskstride, top - row);
-                    set_frame_props(dst, props, vsapi);
+                    debugRowSLRMasked(row, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, top - row);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
             if (bottom != 0) {
                 for (int row = h - bottom; row < h; ++row)
                 {
-                    debugRowSLRMasked(row, w, h, stride, dstp, &props, wmaskp, wmaskstride, bottom + row - h + 1);
-                    set_frame_props(dst, props, vsapi);
+                    debugRowSLRMasked(row, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, bottom + row - h + 1);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
             if (left != 0) {
                 for (int column = left - 1; column > -1; --column)
                 {
-                    debugColumnSLRMasked(column, w, h, stride, dstp, &props, wmaskp, wmaskstride, left - column);
-                    set_frame_props(dst, props, vsapi);
+                    debugColumnSLRMasked(column, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, left - column);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
             if (right != 0) {
                 for (int column = w - right; column < w; ++column)
                 {
-                    debugColumnSLRMasked(column, w, h, stride, dstp, &props, wmaskp, wmaskstride, right + column - w + 1);
-                    set_frame_props(dst, props, vsapi);
+                    debugColumnSLRMasked(column, w, h, stride, dstp, c1_cov11_sumsq, wmaskp, wmaskstride, right + column - w + 1);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
             vsapi->freeFrame(weight_mask);
@@ -222,29 +221,29 @@ static const VSFrame *VS_CC singlePlaneDebugGetFrame(int n, int activationReason
             if (top != 0) {
                 for (int row = top - 1; row > -1; --row)
                 {
-                    debugRowSLR(row, w, h, stride, dstp, &props);
-                    set_frame_props(dst, props, vsapi);
+                    debugRowSLR(row, w, h, stride, dstp, c1_cov11_sumsq);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
             if (bottom != 0) {
                 for (int row = h - bottom; row < h; ++row)
                 {
-                    debugRowSLR(row, w, h, stride, dstp, &props);
-                    set_frame_props(dst, props, vsapi);
+                    debugRowSLR(row, w, h, stride, dstp, c1_cov11_sumsq);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
             if (left != 0) {
                 for (int column = left - 1; column > -1; --column)
                 {
-                    debugColumnSLR(column, w, h, stride, dstp, &props);
-                    set_frame_props(dst, props, vsapi);
+                    debugColumnSLR(column, w, h, stride, dstp, c1_cov11_sumsq);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
             if (right != 0) {
                 for (int column = w - right; column < w; ++column)
                 {
-                    debugColumnSLR(column, w, h, stride, dstp, &props);
-                    set_frame_props(dst, props, vsapi);
+                    debugColumnSLR(column, w, h, stride, dstp, c1_cov11_sumsq);
+                    set_frame_props(dst, c1_cov11_sumsq, vsapi);
                 }
             }
         }

--- a/src/common.c
+++ b/src/common.c
@@ -204,7 +204,7 @@ void processColumnSLRMasked(int column, int w, int h, ptrdiff_t stride, float* _
     free(weights);
 }
 
-void debugRowSLR(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props)
+void debugRowSLR(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq)
 {
     int sign = 1;
     if (row > h / 2)
@@ -223,8 +223,6 @@ void debugRowSLR(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp
         ref[i] = dstp[sign * stride + i];
     }
 
-    double c1_cov11_sumsq[3];
-
     int status = gsl_fit_mul(cur, 1, ref, 1, w, &c1_cov11_sumsq[0], &c1_cov11_sumsq[1], &c1_cov11_sumsq[2]);
 
     if (status || !isfinite(c1_cov11_sumsq[0]))
@@ -232,13 +230,11 @@ void debugRowSLR(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp
         c1_cov11_sumsq[0] = 1.0;
     }
 
-    *props = c1_cov11_sumsq;
-
     free(cur);
     free(ref);
 }
 
-void debugColumnSLR(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props)
+void debugColumnSLR(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq)
 {
     int sign = 1;
     if (column > w / 2)
@@ -257,8 +253,6 @@ void debugColumnSLR(int column, int w, int h, ptrdiff_t stride, float* __restric
         ref[i] = dstp[sign + stride * i];
     }
 
-    double c1_cov11_sumsq[3];
-
     int status = gsl_fit_mul(cur, 1, ref, 1, h, &c1_cov11_sumsq[0], &c1_cov11_sumsq[1], &c1_cov11_sumsq[2]);
 
     if (status || !isfinite(c1_cov11_sumsq[0]))
@@ -266,13 +260,11 @@ void debugColumnSLR(int column, int w, int h, ptrdiff_t stride, float* __restric
         c1_cov11_sumsq[0] = 1.0;
     }
 
-    *props = c1_cov11_sumsq;
-
     free(cur);
     free(ref);
 }
 
-void debugRowSLRMasked(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props,
+void debugRowSLRMasked(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq,
     const float* __restrict wmaskp, ptrdiff_t wmaskstride, int mask_dist)
 {
     int sign = 1;
@@ -296,8 +288,6 @@ void debugRowSLRMasked(int row, int w, int h, ptrdiff_t stride, float* __restric
         weights[i] = wmaskp[i] * wmaskp[sign * mask_dist * wmaskstride + i];
     }
 
-    double c1_cov11_sumsq[3];
-
     int status = gsl_fit_wmul(cur, 1, weights, 1, ref, 1, w, &c1_cov11_sumsq[0], &c1_cov11_sumsq[1], &c1_cov11_sumsq[2]);
 
     if (status || !isfinite(c1_cov11_sumsq[0]))
@@ -305,14 +295,12 @@ void debugRowSLRMasked(int row, int w, int h, ptrdiff_t stride, float* __restric
         c1_cov11_sumsq[0] = 1.0;
     }
 
-    *props = c1_cov11_sumsq;
-
     free(cur);
     free(ref);
     free(weights);
 }
 
-void debugColumnSLRMasked(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props,
+void debugColumnSLRMasked(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq,
     const float* __restrict wmaskp, ptrdiff_t wmaskstride, int mask_dist)
 {
     int sign = 1;
@@ -336,16 +324,12 @@ void debugColumnSLRMasked(int column, int w, int h, ptrdiff_t stride, float* __r
         weights[i] = wmaskp[i * wmaskstride] * wmaskp[sign * mask_dist + wmaskstride * i];
     }
 
-    double c1_cov11_sumsq[3];
-
     int status = gsl_fit_wmul(cur, 1, weights, 1, ref, 1, h, &c1_cov11_sumsq[0], &c1_cov11_sumsq[1], &c1_cov11_sumsq[2]);
 
     if (status || !isfinite(c1_cov11_sumsq[0]))
     {
         c1_cov11_sumsq[0] = 1.0;
     }
-
-    *props = c1_cov11_sumsq;
 
     free(cur);
     free(ref);

--- a/src/common.h
+++ b/src/common.h
@@ -49,11 +49,11 @@ void processRowSLR(int row, int w, int h, ptrdiff_t stride, float* __restrict ds
 void processColumnSLR(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, ...);
 void processRowSLRMasked(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, ...);
 void processColumnSLRMasked(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, ...);
-void debugRowSLR(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props);
-void debugColumnSLR(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props);
-void debugRowSLRMasked(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props,
+void debugRowSLR(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq);
+void debugColumnSLR(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq);
+void debugRowSLRMasked(int row, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq,
     const float* __restrict wmaskp, ptrdiff_t wmaskstride, int mask_dist);
-void debugColumnSLRMasked(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double** props,
+void debugColumnSLRMasked(int column, int w, int h, ptrdiff_t stride, float* __restrict dstp, double* c1_cov11_sumsq,
     const float* __restrict wmaskp, ptrdiff_t wmaskstride, int mask_dist);
 void processRowMLR(int row, int w, int h, ptrdiff_t stride, float* dstp, float* dstp1, float* dstp2, float* dstp3);
 void processColumnMLR(int column, int w, int h, ptrdiff_t stride, float* dstp, float* dstp1, float* dstp2, float* dstp3);


### PR DESCRIPTION
The local array declared inside `debug...()` ends its lifetime upon return, so by the time `set_frame_props` reads the memory, it can contain anything. In particular, in my tests, I consistently get all-zero `BoreAdjustment`.

To ensure the correct values are actually output, put them in a memory location that survives the function return. It seems most natural to have the caller provide this location.

Test binaries: https://github.com/astiob/bore/actions/runs/13777127050